### PR TITLE
Add peering routes and lookup (BGP visibility via public collectors)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod output;
 mod peering;
 mod probing;
+mod ris;
 
 use clap::{Parser, Subcommand};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
@@ -90,6 +91,13 @@ enum PeeringCommands {
     Peerlab {
         #[command(subcommand)]
         command: PeerlabCommands,
+    },
+    #[command(about = "Show your leased prefixes as seen by public BGP collectors (RIPE RIS)")]
+    Routes,
+    #[command(about = "Looking glass: how a prefix is seen by public BGP collectors (RIPE RIS)")]
+    Lookup {
+        #[arg(help = "Prefix or IP to look up (e.g., 2001:db8::/48)")]
+        prefix: String,
     },
 }
 
@@ -181,6 +189,8 @@ async fn handle_peering(command: PeeringCommands) -> anyhow::Result<()> {
         PeeringCommands::Peerlab { command } => match command {
             PeerlabCommands::Env => peering::peerlab_env().await,
         },
+        PeeringCommands::Routes => peering::routes().await,
+        PeeringCommands::Lookup { prefix } => peering::lookup(&prefix).await,
     }
 }
 

--- a/src/peering.rs
+++ b/src/peering.rs
@@ -192,7 +192,7 @@ pub async fn routes() -> anyhow::Result<()> {
         let vis = ris::looking_glass(&lease.prefix).await?;
         let visible = vis.is_visible();
         any_invisible |= !visible;
-        as_of = vis.query_time.clone();
+        as_of = as_of.or_else(|| vis.query_time.clone());
         let origins = vis.origins();
         let propagation = full_feed
             .as_ref()
@@ -217,6 +217,7 @@ pub async fn routes() -> anyhow::Result<()> {
 
     if !output::is_json() {
         let suffix = as_of.map(|t| format!(" (as of {t})")).unwrap_or_default();
+        // AS215011 is PeerLab's export ASN; user (private) ASNs are stripped on export.
         output::info(&format!(
             "\nseen by public BGP collectors (RIPE RIS){suffix}; origin is AS215011 — your ASN is stripped on export"
         ));

--- a/src/peering.rs
+++ b/src/peering.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{api, output};
+use crate::{api, output, ris};
 
 pub async fn asn() -> anyhow::Result<()> {
     #[derive(Deserialize)]
@@ -157,6 +157,138 @@ pub async fn peerlab_env() -> anyhow::Result<()> {
     println!("# Leave empty to not advertise any prefixes (receive-only mode)");
     println!("USER_PREFIXES={prefixes}");
     println!();
+
+    Ok(())
+}
+
+pub async fn routes() -> anyhow::Result<()> {
+    #[derive(Deserialize)]
+    struct PrefixLease {
+        prefix: String,
+    }
+
+    #[derive(Deserialize)]
+    struct UserInfo {
+        active_leases: Vec<PrefixLease>,
+    }
+
+    let user_info: UserInfo = api::ApiClient::new().get("/api/user/info").await?;
+
+    if user_info.active_leases.is_empty() {
+        if output::is_json() {
+            println!("[]");
+        } else {
+            output::info("no active prefix leases — nothing to announce");
+            output::hint("nxthdr peering prefix request <hours>");
+        }
+        return Ok(());
+    }
+
+    let full_feed = ris::full_feed_peers().await.ok();
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut any_invisible = false;
+    let mut as_of: Option<String> = None;
+    for lease in &user_info.active_leases {
+        let vis = ris::looking_glass(&lease.prefix).await?;
+        let visible = vis.is_visible();
+        any_invisible |= !visible;
+        as_of = vis.query_time.clone();
+        let origins = vis.origins();
+        let propagation = full_feed
+            .as_ref()
+            .and_then(|ff| ris::propagation_pct(vis.peer_count(), ff.for_resource(&lease.prefix)))
+            .map(|p| format!("{p}%"))
+            .unwrap_or_else(|| "-".to_string());
+        rows.push(vec![
+            lease.prefix.clone(),
+            if visible { "yes".to_string() } else { "no".to_string() },
+            propagation,
+            vis.collector_count().to_string(),
+            vis.peer_count().to_string(),
+            if origins.is_empty() { "-".to_string() } else { origins.join(", ") },
+            vis.shortest_path().unwrap_or_else(|| "-".to_string()),
+        ]);
+    }
+
+    output::table(
+        &["prefix", "visible", "propagation", "collectors", "peers", "origin", "shortest path"],
+        &rows,
+    );
+
+    if !output::is_json() {
+        let suffix = as_of.map(|t| format!(" (as of {t})")).unwrap_or_default();
+        output::info(&format!(
+            "\nseen by public BGP collectors (RIPE RIS){suffix}; origin is AS215011 — your ASN is stripped on export"
+        ));
+        if any_invisible {
+            output::hint("not visible? new announcements take a few minutes to propagate — re-run shortly");
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn lookup(prefix: &str) -> anyhow::Result<()> {
+    let vis = ris::looking_glass(prefix).await?;
+
+    if !vis.is_visible() {
+        if output::is_json() {
+            println!("[]");
+        } else {
+            output::info(&format!("{prefix} is not visible in any RIPE RIS collector"));
+        }
+        return Ok(());
+    }
+
+    if !output::is_json() {
+        let origins = vis.origins();
+        let origin_str = if origins.is_empty() { "-".to_string() } else { origins.join(", ") };
+        let collectors = vis.collector_count().to_string();
+        let peers = vis.peer_count().to_string();
+        let propagation = ris::full_feed_peers()
+            .await
+            .ok()
+            .and_then(|ff| {
+                let total = ff.for_resource(prefix);
+                ris::propagation_pct(vis.peer_count(), total).map(|p| format!("{p}% of {total} full-feed RIS peers"))
+            });
+        output::section(&format!("looking glass: {prefix}"));
+        let mut pairs: Vec<(&str, &str)> = vec![
+            ("collectors", &collectors),
+            ("peers", &peers),
+            ("origin", &origin_str),
+        ];
+        if let Some(ref p) = propagation {
+            pairs.push(("propagation", p));
+        }
+        if let Some(ref t) = vis.query_time {
+            pairs.push(("as of", t));
+        }
+        output::kv(&pairs);
+        println!();
+    }
+
+    let paths = vis.paths();
+    // JSON is machine-consumed, so emit every path; the terminal table is capped.
+    let shown = if output::is_json() { paths.len() } else { paths.len().min(20) };
+    let rows: Vec<Vec<String>> = paths
+        .iter()
+        .take(shown)
+        .map(|p| {
+            vec![
+                p.origin.clone(),
+                p.as_path.clone(),
+                p.peers.to_string(),
+                p.collectors.to_string(),
+            ]
+        })
+        .collect();
+
+    output::table(&["origin", "as_path", "peers", "collectors"], &rows);
+
+    if !output::is_json() && paths.len() > shown {
+        output::info(&format!("\n… and {} more distinct paths", paths.len() - shown));
+    }
 
     Ok(())
 }

--- a/src/ris.rs
+++ b/src/ris.rs
@@ -1,0 +1,215 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+const DEFAULT_RIS_URL: &str = "https://stat.ripe.net";
+
+#[derive(Deserialize)]
+struct Envelope {
+    data: LgData,
+}
+
+#[derive(Deserialize)]
+struct LgData {
+    #[serde(default)]
+    rrcs: Vec<Rrc>,
+    #[serde(default)]
+    query_time: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Rrc {
+    #[serde(default)]
+    rrc: String,
+    #[serde(default)]
+    peers: Vec<Peer>,
+}
+
+#[derive(Deserialize)]
+struct Peer {
+    #[serde(default)]
+    asn_origin: String,
+    #[serde(default)]
+    as_path: String,
+}
+
+/// One distinct AS path observed for a resource, with how widely it is seen.
+pub struct PathStat {
+    pub origin: String,
+    pub as_path: String,
+    pub peers: usize,
+    pub collectors: usize,
+}
+
+/// Aggregated RIS looking-glass view of a single resource (prefix or IP).
+pub struct Visibility {
+    pub query_time: Option<String>,
+    rrcs: Vec<Rrc>,
+}
+
+impl Visibility {
+    /// Total number of RIS peers observing the resource.
+    pub fn peer_count(&self) -> usize {
+        self.rrcs.iter().map(|r| r.peers.len()).sum()
+    }
+
+    /// Number of route collectors (RRCs) with at least one peer seeing it.
+    pub fn collector_count(&self) -> usize {
+        self.rrcs.iter().filter(|r| !r.peers.is_empty()).count()
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.peer_count() > 0
+    }
+
+    /// Distinct origin ASNs observed across all peers.
+    pub fn origins(&self) -> Vec<String> {
+        self.rrcs
+            .iter()
+            .flat_map(|r| r.peers.iter())
+            .filter(|p| !p.asn_origin.is_empty())
+            .map(|p| p.asn_origin.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    /// The shortest AS path observed (fewest hops), if any.
+    pub fn shortest_path(&self) -> Option<String> {
+        self.rrcs
+            .iter()
+            .flat_map(|r| r.peers.iter())
+            .map(|p| p.as_path.clone())
+            .filter(|p| !p.is_empty())
+            .min_by_key(|p| p.split_whitespace().count())
+    }
+
+    /// Distinct AS paths, each annotated with how many peers and collectors
+    /// observe it, sorted by peer count (most-seen first).
+    pub fn paths(&self) -> Vec<PathStat> {
+        let mut map: BTreeMap<String, (String, usize, BTreeSet<String>)> = BTreeMap::new();
+        for r in &self.rrcs {
+            for p in &r.peers {
+                if p.as_path.is_empty() {
+                    continue;
+                }
+                let entry = map
+                    .entry(p.as_path.clone())
+                    .or_insert_with(|| (p.asn_origin.clone(), 0, BTreeSet::new()));
+                entry.1 += 1;
+                entry.2.insert(r.rrc.clone());
+            }
+        }
+        let mut paths: Vec<PathStat> = map
+            .into_iter()
+            .map(|(as_path, (origin, peers, rrcs))| PathStat {
+                origin,
+                as_path,
+                peers,
+                collectors: rrcs.len(),
+            })
+            .collect();
+        paths.sort_by(|a, b| {
+            b.peers
+                .cmp(&a.peers)
+                .then_with(|| a.as_path.split_whitespace().count().cmp(&b.as_path.split_whitespace().count()))
+        });
+        paths
+    }
+}
+
+/// Number of RIS peers carrying a full table (v4, v6). These "full-feed" peers
+/// are the universe that should see any globally-propagated prefix, so they make
+/// the natural denominator for a propagation percentage.
+pub struct FullFeedPeers {
+    pub v4: u64,
+    pub v6: u64,
+}
+
+impl FullFeedPeers {
+    /// Pick the denominator matching a resource's address family.
+    pub fn for_resource(&self, resource: &str) -> u64 {
+        if resource.contains(':') {
+            self.v6
+        } else {
+            self.v4
+        }
+    }
+}
+
+/// Fetch the current count of full-feed RIS peers (v4 and v6) from RIPEstat's
+/// lightweight ris-peer-count endpoint.
+pub async fn full_feed_peers() -> Result<FullFeedPeers> {
+    let base = std::env::var("NXTHDR_RIS_URL").unwrap_or_else(|_| DEFAULT_RIS_URL.to_string());
+    let url = format!("{base}/data/ris-peer-count/data.json?sourceapp=nxthdr-cli");
+
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .header("User-Agent", "nxthdr-cli")
+        .send()
+        .await
+        .context("Failed to query RIPEstat")?;
+
+    if !resp.status().is_success() {
+        anyhow::bail!("RIPEstat ris-peer-count failed with status {}", resp.status());
+    }
+
+    let body: serde_json::Value = resp.json().await.context("Failed to parse RIPEstat response")?;
+    let pc = &body["data"]["peer_count"];
+    // full_feed is a time series; take the latest sample.
+    let latest = |fam: &str| -> u64 {
+        pc[fam]["full_feed"]
+            .as_array()
+            .and_then(|a| a.last())
+            .and_then(|s| s["count"].as_u64())
+            .unwrap_or(0)
+    };
+    Ok(FullFeedPeers {
+        v4: latest("v4"),
+        v6: latest("v6"),
+    })
+}
+
+/// Compute a propagation percentage (0-100) of full-feed peers that see the
+/// resource. Returns None when the denominator is unavailable.
+pub fn propagation_pct(peers_seeing: usize, full_feed: u64) -> Option<u8> {
+    if full_feed == 0 {
+        return None;
+    }
+    Some(((peers_seeing as u64 * 100 / full_feed).min(100)) as u8)
+}
+
+/// Query the RIPEstat looking-glass for a resource (prefix or IP) and return an
+/// aggregated view of how public BGP collectors (RIPE RIS) currently see it.
+pub async fn looking_glass(resource: &str) -> Result<Visibility> {
+    let base = std::env::var("NXTHDR_RIS_URL").unwrap_or_else(|_| DEFAULT_RIS_URL.to_string());
+    let url = format!(
+        "{base}/data/looking-glass/data.json?resource={}&sourceapp=nxthdr-cli",
+        urlencoding::encode(resource)
+    );
+
+    tracing::debug!("RIS looking-glass: {url}");
+
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .header("User-Agent", "nxthdr-cli")
+        .send()
+        .await
+        .context("Failed to query RIPEstat")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        anyhow::bail!(
+            "RIPEstat request failed with status {}: {}",
+            status,
+            resp.text().await.unwrap_or_default().trim()
+        );
+    }
+
+    let envelope: Envelope = resp.json().await.context("Failed to parse RIPEstat response")?;
+    Ok(Visibility {
+        query_time: envelope.data.query_time,
+        rrcs: envelope.data.rrcs,
+    })
+}

--- a/src/ris.rs
+++ b/src/ris.rs
@@ -5,6 +5,15 @@ use serde::Deserialize;
 
 const DEFAULT_RIS_URL: &str = "https://stat.ripe.net";
 
+/// HTTP client with a timeout so a slow or unresponsive RIPEstat (a public
+/// external service) can't hang the CLI indefinitely.
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .unwrap_or_default()
+}
+
 #[derive(Deserialize)]
 struct Envelope {
     data: LgData,
@@ -138,13 +147,40 @@ impl FullFeedPeers {
     }
 }
 
+#[derive(Deserialize)]
+struct PeerCountEnvelope {
+    data: PeerCountData,
+}
+
+#[derive(Deserialize)]
+struct PeerCountData {
+    peer_count: PeerCountFamilies,
+}
+
+#[derive(Deserialize)]
+struct PeerCountFamilies {
+    v4: FeedSeries,
+    v6: FeedSeries,
+}
+
+#[derive(Deserialize)]
+struct FeedSeries {
+    #[serde(default)]
+    full_feed: Vec<CountSample>,
+}
+
+#[derive(Deserialize)]
+struct CountSample {
+    count: u64,
+}
+
 /// Fetch the current count of full-feed RIS peers (v4 and v6) from RIPEstat's
 /// lightweight ris-peer-count endpoint.
 pub async fn full_feed_peers() -> Result<FullFeedPeers> {
     let base = std::env::var("NXTHDR_RIS_URL").unwrap_or_else(|_| DEFAULT_RIS_URL.to_string());
     let url = format!("{base}/data/ris-peer-count/data.json?sourceapp=nxthdr-cli");
 
-    let resp = reqwest::Client::new()
+    let resp = client()
         .get(&url)
         .header("User-Agent", "nxthdr-cli")
         .send()
@@ -155,19 +191,12 @@ pub async fn full_feed_peers() -> Result<FullFeedPeers> {
         anyhow::bail!("RIPEstat ris-peer-count failed with status {}", resp.status());
     }
 
-    let body: serde_json::Value = resp.json().await.context("Failed to parse RIPEstat response")?;
-    let pc = &body["data"]["peer_count"];
-    // full_feed is a time series; take the latest sample.
-    let latest = |fam: &str| -> u64 {
-        pc[fam]["full_feed"]
-            .as_array()
-            .and_then(|a| a.last())
-            .and_then(|s| s["count"].as_u64())
-            .unwrap_or(0)
-    };
+    let body: PeerCountEnvelope = resp.json().await.context("Failed to parse RIPEstat response")?;
+    // full_feed is a time series; take the latest sample for each family.
+    let latest = |series: &FeedSeries| series.full_feed.last().map(|s| s.count).unwrap_or(0);
     Ok(FullFeedPeers {
-        v4: latest("v4"),
-        v6: latest("v6"),
+        v4: latest(&body.data.peer_count.v4),
+        v6: latest(&body.data.peer_count.v6),
     })
 }
 
@@ -191,7 +220,7 @@ pub async fn looking_glass(resource: &str) -> Result<Visibility> {
 
     tracing::debug!("RIS looking-glass: {url}");
 
-    let resp = reqwest::Client::new()
+    let resp = client()
         .get(&url)
         .header("User-Agent", "nxthdr-cli")
         .send()


### PR DESCRIPTION
## Peering feedback loop — `routes` + `lookup`

Implements the **Peering — close the feedback loop** item of the v2 CLI scope (nxthdr/roadmap#38):

- **`nxthdr peering routes`** — your active leased prefixes as currently seen by public BGP collectors (RIPE RIS): `visible`, `propagation %`, collectors/peers, origin AS, shortest AS path.
- **`nxthdr peering lookup <prefix>`** — looking glass for any prefix/IP: origin AS, distinct AS paths ranked by how many peers/collectors observe each.

Both support `-o json`. Machine output is **complete**; the text table caps long path lists with a "… N more" note.

### Data source
Uses **RIPEstat** (`looking-glass` + `ris-peer-count`) — public, no API key, sub-second, near-real-time.

We deliberately do **not** use nxthdr's own `bmp.updates` here: it's a *deduplicated update stream with a 7-day TTL*, not a current RIB, so it can't reliably answer "is my prefix announced right now" (a stable announcement emits once then ages out, and risotto's persisted dedup state can diverge). That gap deserves its own fix — see follow-ups.

### Notes
- At collectors, PeerLab prefixes appear originated by **AS215011** — the user's private ASN is stripped on export — and the output says so.
- `propagation` = `peers_seeing / full-feed RIS peers` (clamped, address-family aware). Full-feed peers are the universe that *should* see a propagated prefix. RIPEstat's official `routing-status` percentage was rejected because it lags real BGP by tens of minutes (reported 0% for a prefix live at 22 collectors).
- **RIS-only** coverage (no RouteViews). Combined coverage and per-collector arrival timing would use BGPKit `monocle` (MRT) — earmarked as a future "deep analysis" backend.

### Validation
End-to-end against a live PeerLab announcement (lease → announce → watched `routes` flip to visible, ~94% propagation / 22 of ~23 collectors), plus `lookup` on `8.8.8.0/24`, `1.1.1.1`, and unannounced prefixes.

### Follow-ups (not in this PR)
- Document `routes`/`lookup` on the website (`docs/tools/cli.md`).
- Roadmap issue: a **BGP RIB/state table in ClickHouse** (the dedup / no-state finding above).
- `--version`/`-V` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
