### PR TITLE
test: verify claude[bot] review attribution (throwaway)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,13 +27,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          token: ${{ secrets.CLAUDE_GITHUB_PAT }}
 
+      # No github_token: review is comment-only, so it uses the official Claude
+      # GitHub App's built-in auth and posts as claude[bot]. The PAT is only kept
+      # in claude.yml (tag mode), where Claude's commits must trigger CI.
       - name: Run Claude Review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.CLAUDE_GITHUB_PAT }}
           track_progress: true
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,6 +22,10 @@ jobs:
       pull-requests: write
       issues: write
       actions: read
+      # Required for the official Claude App path (no PAT): the action mints its
+      # GitHub App installation token via an OIDC exchange. Without this the run
+      # fails with "Could not fetch an OIDC token".
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/BOT_TEST.md
+++ b/BOT_TEST.md
@@ -1,0 +1,1 @@
+# scratch — verifying claude[bot] attribution on PR open; this PR will be closed


### PR DESCRIPTION
Throwaway PR to confirm the auto-review posts as claude[bot] after the id-token fix. Will be closed without merging.