### PR TITLE
ci: make Claude Review advisory (never block PRs)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,6 +31,11 @@ jobs:
 
       - name: Run Claude Review
         uses: anthropics/claude-code-action@v1
+        # The review is advisory: it posts findings but must never block a PR.
+        # claude-code-action exits non-zero when it hits --max-turns, so without
+        # this the job goes red even though the review ran. Keep CI green and let
+        # the posted review speak for itself.
+        continue-on-error: true
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.CLAUDE_GITHUB_PAT }}
@@ -41,4 +46,4 @@ jobs:
             conventions. Report important findings only; skip nits. Use inline
             comments on the relevant lines where it helps.
           claude_args: |
-            --max-turns 5
+            --max-turns 20


### PR DESCRIPTION
## Problem

The `Claude Review` check went red on #14 with:

> Claude execution failed: Reached maximum number of turns (5)

`anthropics/claude-code-action` exits non-zero when it hits `--max-turns`, and that propagates to the job — so the PR check fails **even though the review ran and posted its findings**. A review running out of turns is not a signal that the PR is bad, so it shouldn't block a merge.

## Fix

- **`continue-on-error: true`** on the review step → the review is advisory: it still posts its comments, but neither a turn-limit stop nor any other action error turns CI red.
- **`--max-turns 5 → 20`** so the review has room to actually finish its analysis (with `track_progress: true` the 5-turn budget was spent before it completed). `timeout-minutes: 15` stays as the wall-clock guard.

## Notes

- `claude-review.yml` triggers only on `pull_request: opened`, so this won't re-run on the already-opened PRs; it applies to PRs opened after merge. Existing red checks can be cleared by re-running the job or re-opening.
- saimiris-gateway has no `claude-review.yml`, so no mirror is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)