### PR TITLE
probing measurements: filtering & sorting flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,18 @@ enum ProbingCommands {
     Measurements {
         #[arg(long, default_value_t = 20, help = "Maximum number of measurements to list (1-100)")]
         limit: u32,
+        #[arg(long, value_delimiter = ',', help = "Filter by status (comma-separated): complete, in-progress, cancelled")]
+        status: Vec<probing::StatusFilter>,
+        #[arg(long, help = "Only measurements started at/after this time (e.g. '2026-03-22' or '2026-03-22 10:00:00')")]
+        since: Option<String>,
+        #[arg(long, help = "Only measurements started at/before this time")]
+        until: Option<String>,
+        #[arg(long, help = "Only measurements involving this agent ID")]
+        agent: Option<String>,
+        #[arg(long, value_enum, default_value = "updated", help = "Sort by 'started' or 'updated' time")]
+        sort: probing::SortField,
+        #[arg(long, help = "Reverse the order (oldest first)")]
+        reverse: bool,
     },
     #[command(about = "Get status of a measurement by ID")]
     MeasurementStatus {
@@ -180,7 +192,9 @@ async fn handle_probing(command: ProbingCommands) -> anyhow::Result<()> {
         ProbingCommands::Agents => probing::agents().await,
         ProbingCommands::Send { file, agent, src_ip } => probing::send(file, agent, src_ip).await,
         ProbingCommands::Results { src_ip, since, until } => probing::results(src_ip, since, until).await,
-        ProbingCommands::Measurements { limit } => probing::measurements(limit).await,
+        ProbingCommands::Measurements { limit, status, since, until, agent, sort, reverse } => {
+            probing::measurements(limit, status, since, until, agent, sort, reverse).await
+        }
         ProbingCommands::MeasurementStatus { id } => probing::measurement_status(&id).await,
         ProbingCommands::Cancel { id } => probing::cancel(&id).await,
     }

--- a/src/probing.rs
+++ b/src/probing.rs
@@ -279,7 +279,50 @@ fn measurement_label(cancelled: bool, complete: bool) -> &'static str {
     }
 }
 
-pub async fn measurements(limit: u32) -> anyhow::Result<()> {
+/// Status filter for `measurements` (clap derives kebab-case value names:
+/// `complete`, `in-progress`, `cancelled`).
+#[derive(Clone, Copy, clap::ValueEnum)]
+pub enum StatusFilter {
+    Complete,
+    InProgress,
+    Cancelled,
+}
+
+impl StatusFilter {
+    fn as_query(self) -> &'static str {
+        match self {
+            StatusFilter::Complete => "complete",
+            StatusFilter::InProgress => "in-progress",
+            StatusFilter::Cancelled => "cancelled",
+        }
+    }
+}
+
+/// Sort field for `measurements`.
+#[derive(Clone, Copy, clap::ValueEnum)]
+pub enum SortField {
+    Started,
+    Updated,
+}
+
+impl SortField {
+    fn as_query(self) -> &'static str {
+        match self {
+            SortField::Started => "started",
+            SortField::Updated => "updated",
+        }
+    }
+}
+
+pub async fn measurements(
+    limit: u32,
+    status: Vec<StatusFilter>,
+    since: Option<String>,
+    until: Option<String>,
+    agent: Option<String>,
+    sort: SortField,
+    reverse: bool,
+) -> anyhow::Result<()> {
     anyhow::ensure!((1..=100).contains(&limit), "--limit must be between 1 and 100");
 
     #[derive(Deserialize)]
@@ -295,8 +338,28 @@ pub async fn measurements(limit: u32) -> anyhow::Result<()> {
         started_at: String,
     }
 
+    // Filters are applied server-side, before the limit.
+    let mut query: Vec<String> = vec![format!("limit={limit}")];
+    if !status.is_empty() {
+        let joined = status.iter().map(|s| s.as_query()).collect::<Vec<_>>().join(",");
+        query.push(format!("status={}", urlencoding::encode(&joined)));
+    }
+    if let Some(ref s) = since {
+        query.push(format!("since={}", urlencoding::encode(s)));
+    }
+    if let Some(ref u) = until {
+        query.push(format!("until={}", urlencoding::encode(u)));
+    }
+    if let Some(ref a) = agent {
+        query.push(format!("agent={}", urlencoding::encode(a)));
+    }
+    query.push(format!("sort={}", sort.as_query()));
+    if reverse {
+        query.push("reverse=true".to_string());
+    }
+
     let measurements: Vec<Measurement> = api::ApiClient::new_saimiris()
-        .get(&format!("/api/measurements?limit={limit}"))
+        .get(&format!("/api/measurements?{}", query.join("&")))
         .await?;
 
     if measurements.is_empty() {

--- a/src/probing.rs
+++ b/src/probing.rs
@@ -279,8 +279,7 @@ fn measurement_label(cancelled: bool, complete: bool) -> &'static str {
     }
 }
 
-/// Status filter for `measurements` (clap derives kebab-case value names:
-/// `complete`, `in-progress`, `cancelled`).
+/// Status filter; clap derives kebab-case names: complete, in-progress, cancelled.
 #[derive(Clone, Copy, clap::ValueEnum)]
 pub enum StatusFilter {
     Complete,
@@ -298,7 +297,6 @@ impl StatusFilter {
     }
 }
 
-/// Sort field for `measurements`.
 #[derive(Clone, Copy, clap::ValueEnum)]
 pub enum SortField {
     Started,
@@ -341,8 +339,10 @@ pub async fn measurements(
     // Filters are applied server-side, before the limit.
     let mut query: Vec<String> = vec![format!("limit={limit}")];
     if !status.is_empty() {
+        // enum values are ASCII-safe; keep the comma literal so the gateway, which
+        // splits on ',' after URL-decoding, sees the separator.
         let joined = status.iter().map(|s| s.as_query()).collect::<Vec<_>>().join(",");
-        query.push(format!("status={}", urlencoding::encode(&joined)));
+        query.push(format!("status={joined}"));
     }
     if let Some(ref s) = since {
         query.push(format!("since={}", urlencoding::encode(s)));


### PR DESCRIPTION
Adds the filter/sort flags to `nxthdr probing measurements`, passing them through to the new server-side params in **saimiris-gateway#51** (roadmap nxthdr/roadmap#38):

- `--status` — `complete|in-progress|cancelled`, comma-separated (clap `ValueEnum`)
- `--since` / `--until` — start-time window (e.g. `'2026-03-22'` or `'2026-03-22 10:00:00'`)
- `--agent` — only measurements involving that agent
- `--sort started|updated` (default `updated`), `--reverse`

Filters are applied server-side (before the limit), so `--status cancelled` searches all measurements, not just the newest page. Query params are URL-encoded; verified the constructed URL via `-v`.

> Depends on saimiris-gateway#51 being merged + deployed — until then the gateway ignores the new params (returns unfiltered). End-to-end test after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)