### PR TITLE
probing: nest single-measurement ops under `measurement`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,19 +46,10 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum ProbingCommands {
-    #[command(about = "Show your probing credits usage")]
-    Credits,
     #[command(about = "List available probing agents")]
     Agents,
-    #[command(about = "Query replies from ClickHouse")]
-    Results {
-        #[arg(long, help = "Source IP(s) to filter by", required = true, num_args = 1..)]
-        src_ip: Vec<String>,
-        #[arg(long, help = "Start of time window (e.g. '2026-03-19 21:00:00')")]
-        since: Option<String>,
-        #[arg(long, help = "End of time window (e.g. '2026-03-19 22:00:00')")]
-        until: Option<String>,
-    },
+    #[command(about = "Show your probing credits usage")]
+    Credits,
     #[command(
         about = "Send probes from one or more agents",
         long_about = "Send probes read from a file or stdin.\n\nEach line must be: dst_addr,src_port,dst_port,ttl,protocol\nProtocol is 'icmpv6' or 'udp' (case-insensitive).\n\nExamples:\n  nxthdr probing send --agent vltcdg01 probes.csv\n  prowl | nxthdr probing send --agent vltcdg01"
@@ -88,8 +79,26 @@ enum ProbingCommands {
         #[arg(long, help = "Reverse the order (oldest first)")]
         reverse: bool,
     },
+    #[command(about = "Inspect or cancel a single measurement")]
+    Measurement {
+        #[command(subcommand)]
+        command: MeasurementCommands,
+    },
+    #[command(about = "Query replies from ClickHouse")]
+    Results {
+        #[arg(long, help = "Source IP(s) to filter by", required = true, num_args = 1..)]
+        src_ip: Vec<String>,
+        #[arg(long, help = "Start of time window (e.g. '2026-03-19 21:00:00')")]
+        since: Option<String>,
+        #[arg(long, help = "End of time window (e.g. '2026-03-19 22:00:00')")]
+        until: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum MeasurementCommands {
     #[command(about = "Get status of a measurement by ID")]
-    MeasurementStatus {
+    Status {
         #[arg(help = "Measurement ID returned by 'send'")]
         id: String,
     },
@@ -195,8 +204,10 @@ async fn handle_probing(command: ProbingCommands) -> anyhow::Result<()> {
         ProbingCommands::Measurements { limit, status, since, until, agent, sort, reverse } => {
             probing::measurements(limit, status, since, until, agent, sort, reverse).await
         }
-        ProbingCommands::MeasurementStatus { id } => probing::measurement_status(&id).await,
-        ProbingCommands::Cancel { id } => probing::cancel(&id).await,
+        ProbingCommands::Measurement { command } => match command {
+            MeasurementCommands::Status { id } => probing::measurement_status(&id).await,
+            MeasurementCommands::Cancel { id } => probing::cancel(&id).await,
+        },
     }
 }
 

--- a/src/probing.rs
+++ b/src/probing.rs
@@ -199,7 +199,7 @@ pub async fn send(
     output::kv(&pairs);
 
     let hint = agent_src.iter().map(|(_, ip)| format!("--src-ip {ip}")).collect::<Vec<_>>().join(" ");
-    output::hint(&format!("nxthdr probing measurement-status {}", response.id));
+    output::hint(&format!("nxthdr probing measurement status {}", response.id));
     output::hint(&format!("nxthdr probing results {hint}"));
 
     Ok(())
@@ -382,7 +382,7 @@ pub async fn measurements(
     }).collect();
 
     output::table(&["id", "started", "agents", "probes", "status"], &rows);
-    output::hint("nxthdr probing measurement-status <id>");
+    output::hint("nxthdr probing measurement status <id>");
 
     Ok(())
 }
@@ -467,7 +467,7 @@ pub async fn cancel(id: &str) -> anyhow::Result<()> {
         ("agents_cancelled", &resp.agents_cancelled.to_string()),
         ("message", &resp.message),
     ]);
-    output::hint(&format!("nxthdr probing measurement-status {id}"));
+    output::hint(&format!("nxthdr probing measurement status {id}"));
 
     Ok(())
 }


### PR DESCRIPTION
Tidies the `probing` subcommands.

**New shape:**
```
nxthdr probing measurements              # list (plural = collection)
nxthdr probing measurement status <id>   # was: measurement-status
nxthdr probing measurement cancel <id>   # was: cancel
```
`measurement` (singular) is now a subcommand group for single-measurement ops, mirroring the existing `peering prefix {list,request,revoke,rpki}` nesting. Top-level `probing` commands reordered into workflow order: `agents, credits, send, measurements, measurement, results`.

**⚠️ Breaking** (intentional, pre-1.0 beta): `measurement-status` shipped in v0.5.0, so its rename breaks that invocation; `cancel` was post-v0.5.0 (unreleased). Land **before** cutting the next release tag. Next-step hints printed by `send`/`measurements`/`measurement cancel` updated to the new paths.

Gateway endpoints are unchanged — this is purely the CLI command surface. Docs PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)