### PR TITLE
cli: consistent resource-then-verb command structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 cargo build                       # build (CI runs `cargo build --verbose`)
 cargo test                        # run tests (CI runs `cargo test --verbose`)
 cargo test <name>                 # run a single test by name substring
-cargo run -- <args>               # run locally, e.g. `cargo run -- peering routes`
+cargo run -- <args>               # run locally, e.g. `cargo run -- peering prefix routes`
 cargo run -- -o json <args>       # force JSON output
 cargo fmt && cargo clippy         # format + lint (not enforced in CI, but expected)
 ```
@@ -48,7 +48,7 @@ The CLI is organized as thin layers; command modules call a shared HTTP client a
 
 ## Domain notes
 
-- **Peering / RIS:** leased prefixes are announced via PeerLab's export ASN **AS215011** — a user's private ASN is stripped on export, so `peering routes` reports AS215011 as origin. Visibility/propagation come from public RIPE RIS collectors and lag announcements by a few minutes.
-- **Probing source IPs:** `probing send` derives each agent's IPv6 source address by overwriting the host bits of the agent's allocated prefix with a **single shared random 48-bit value** (`random_host_48`), so all replies from one measurement share an identifier and can be queried together without server-side state. `--src-ip` overrides this.
-- **Probe input format:** `probing send` reads CSV lines `dst_addr,src_port,dst_port,ttl,protocol` (protocol `icmpv6`|`udp`) from a file or stdin; `#` comments and blank lines are skipped.
-- **Results:** `probing results` queries the public read-only ClickHouse endpoint (table `saimiris.replies`) directly over HTTP, bypassing the platform API.
+- **Peering / RIS:** leased prefixes are announced via PeerLab's export ASN **AS215011** — a user's private ASN is stripped on export, so `peering prefix routes` reports AS215011 as origin. Visibility/propagation come from public RIPE RIS collectors and lag announcements by a few minutes.
+- **Probing source IPs:** `probing measurement send` derives each agent's IPv6 source address by overwriting the host bits of the agent's allocated prefix with a **single shared random 48-bit value** (`random_host_48`), so all replies from one measurement share an identifier and can be queried together without server-side state. `--src-ip` overrides this.
+- **Probe input format:** `probing measurement send` reads CSV lines `dst_addr,src_port,dst_port,ttl,protocol` (protocol `icmpv6`|`udp`) from a file or stdin; `#` comments and blank lines are skipped.
+- **Replies:** `probing reply list` queries the public read-only ClickHouse endpoint (table `saimiris.replies`) directly over HTTP, bypassing the platform API.

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,13 +46,36 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum ProbingCommands {
-    #[command(about = "List available probing agents")]
-    Agents,
+    #[command(about = "Manage probing agents")]
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommands,
+    },
     #[command(about = "Show your probing credits usage")]
     Credits,
+    #[command(about = "Send, list, and manage measurements")]
+    Measurement {
+        #[command(subcommand)]
+        command: MeasurementCommands,
+    },
+    #[command(about = "Query probe replies")]
+    Reply {
+        #[command(subcommand)]
+        command: ReplyCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentCommands {
+    #[command(about = "List available probing agents")]
+    List,
+}
+
+#[derive(Subcommand)]
+enum MeasurementCommands {
     #[command(
         about = "Send probes from one or more agents",
-        long_about = "Send probes read from a file or stdin.\n\nEach line must be: dst_addr,src_port,dst_port,ttl,protocol\nProtocol is 'icmpv6' or 'udp' (case-insensitive).\n\nExamples:\n  nxthdr probing send --agent vltcdg01 probes.csv\n  prowl | nxthdr probing send --agent vltcdg01"
+        long_about = "Send probes read from a file or stdin.\n\nEach line must be: dst_addr,src_port,dst_port,ttl,protocol\nProtocol is 'icmpv6' or 'udp' (case-insensitive).\n\nExamples:\n  nxthdr probing measurement send --agent vltcdg01 probes.csv\n  prowl | nxthdr probing measurement send --agent vltcdg01"
     )]
     Send {
         #[arg(help = "Input file with probes (reads from stdin if omitted)")]
@@ -63,7 +86,7 @@ enum ProbingCommands {
         src_ip: Option<String>,
     },
     #[command(about = "List your recent measurements")]
-    Measurements {
+    List {
         #[arg(long, default_value_t = 20, help = "Maximum number of measurements to list (1-100)")]
         limit: u32,
         #[arg(long, value_delimiter = ',', help = "Filter by status (comma-separated): complete, in-progress, cancelled")]
@@ -79,26 +102,8 @@ enum ProbingCommands {
         #[arg(long, help = "Reverse the order (oldest first)")]
         reverse: bool,
     },
-    #[command(about = "Inspect or cancel a single measurement")]
-    Measurement {
-        #[command(subcommand)]
-        command: MeasurementCommands,
-    },
-    #[command(about = "Query replies from ClickHouse")]
-    Results {
-        #[arg(long, help = "Source IP(s) to filter by", required = true, num_args = 1..)]
-        src_ip: Vec<String>,
-        #[arg(long, help = "Start of time window (e.g. '2026-03-19 21:00:00')")]
-        since: Option<String>,
-        #[arg(long, help = "End of time window (e.g. '2026-03-19 22:00:00')")]
-        until: Option<String>,
-    },
-}
-
-#[derive(Subcommand)]
-enum MeasurementCommands {
     #[command(about = "Get status of a measurement by ID")]
-    Status {
+    Get {
         #[arg(help = "Measurement ID returned by 'send'")]
         id: String,
     },
@@ -110,26 +115,46 @@ enum MeasurementCommands {
 }
 
 #[derive(Subcommand)]
+enum ReplyCommands {
+    #[command(about = "Query replies from ClickHouse")]
+    List {
+        #[arg(long, help = "Source IP(s) to filter by", required = true, num_args = 1..)]
+        src_ip: Vec<String>,
+        #[arg(long, help = "Start of time window (e.g. '2026-03-19 21:00:00')")]
+        since: Option<String>,
+        #[arg(long, help = "End of time window (e.g. '2026-03-19 22:00:00')")]
+        until: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 enum PeeringCommands {
-    #[command(about = "Get your ASN")]
-    Asn,
+    #[command(about = "Manage your ASN")]
+    Asn {
+        #[command(subcommand)]
+        command: AsnCommands,
+    },
     #[command(about = "Manage prefix leases")]
     Prefix {
         #[command(subcommand)]
         command: PrefixCommands,
+    },
+    #[command(about = "Looking glass: how a prefix is seen by public BGP collectors (RIPE RIS)")]
+    Lookup {
+        #[arg(help = "Prefix or IP to look up (e.g., 2001:db8::/48)")]
+        prefix: String,
     },
     #[command(about = "PeerLab utilities")]
     Peerlab {
         #[command(subcommand)]
         command: PeerlabCommands,
     },
-    #[command(about = "Show your leased prefixes as seen by public BGP collectors (RIPE RIS)")]
-    Routes,
-    #[command(about = "Looking glass: how a prefix is seen by public BGP collectors (RIPE RIS)")]
-    Lookup {
-        #[arg(help = "Prefix or IP to look up (e.g., 2001:db8::/48)")]
-        prefix: String,
-    },
+}
+
+#[derive(Subcommand)]
+enum AsnCommands {
+    #[command(about = "Get your ASN")]
+    Get,
 }
 
 #[derive(Subcommand)]
@@ -152,6 +177,8 @@ enum PrefixCommands {
         #[arg(help = "Prefix to revoke (e.g., 2001:db8::/48)")]
         prefix: String,
     },
+    #[command(about = "Show your leased prefixes as seen by public BGP collectors (RIPE RIS)")]
+    Routes,
     #[command(about = "Manage RPKI ROA for a leased prefix")]
     Rpki {
         #[command(subcommand)]
@@ -197,37 +224,47 @@ async fn main() -> anyhow::Result<()> {
 
 async fn handle_probing(command: ProbingCommands) -> anyhow::Result<()> {
     match command {
+        ProbingCommands::Agent { command } => match command {
+            AgentCommands::List => probing::agents().await,
+        },
         ProbingCommands::Credits => probing::credits().await,
-        ProbingCommands::Agents => probing::agents().await,
-        ProbingCommands::Send { file, agent, src_ip } => probing::send(file, agent, src_ip).await,
-        ProbingCommands::Results { src_ip, since, until } => probing::results(src_ip, since, until).await,
-        ProbingCommands::Measurements { limit, status, since, until, agent, sort, reverse } => {
-            probing::measurements(limit, status, since, until, agent, sort, reverse).await
-        }
         ProbingCommands::Measurement { command } => match command {
-            MeasurementCommands::Status { id } => probing::measurement_status(&id).await,
+            MeasurementCommands::Send { file, agent, src_ip } => {
+                probing::send(file, agent, src_ip).await
+            }
+            MeasurementCommands::List { limit, status, since, until, agent, sort, reverse } => {
+                probing::measurements(limit, status, since, until, agent, sort, reverse).await
+            }
+            MeasurementCommands::Get { id } => probing::measurement_status(&id).await,
             MeasurementCommands::Cancel { id } => probing::cancel(&id).await,
+        },
+        ProbingCommands::Reply { command } => match command {
+            ReplyCommands::List { src_ip, since, until } => {
+                probing::results(src_ip, since, until).await
+            }
         },
     }
 }
 
 async fn handle_peering(command: PeeringCommands) -> anyhow::Result<()> {
     match command {
-        PeeringCommands::Asn => peering::asn().await,
+        PeeringCommands::Asn { command } => match command {
+            AsnCommands::Get => peering::asn().await,
+        },
         PeeringCommands::Prefix { command } => match command {
             PrefixCommands::List => peering::prefix_list().await,
             PrefixCommands::Request { duration } => peering::prefix_request(duration).await,
             PrefixCommands::Revoke { prefix } => peering::prefix_revoke(&prefix).await,
+            PrefixCommands::Routes => peering::routes().await,
             PrefixCommands::Rpki { command } => match command {
                 RpkiCommands::Enable { prefix } => peering::prefix_rpki(&prefix, true).await,
                 RpkiCommands::Disable { prefix } => peering::prefix_rpki(&prefix, false).await,
             },
         },
+        PeeringCommands::Lookup { prefix } => peering::lookup(&prefix).await,
         PeeringCommands::Peerlab { command } => match command {
             PeerlabCommands::Env => peering::peerlab_env().await,
         },
-        PeeringCommands::Routes => peering::routes().await,
-        PeeringCommands::Lookup { prefix } => peering::lookup(&prefix).await,
     }
 }
 

--- a/src/probing.rs
+++ b/src/probing.rs
@@ -167,7 +167,7 @@ pub async fn send(
             let agent_entry = user_prefixes.agents.iter()
                 .find(|a| &a.agent_id == agent_id)
                 .ok_or_else(|| anyhow::anyhow!(
-                    "No prefix allocated for agent '{agent_id}'. Run 'nxthdr probing agents' to see available agents."
+                    "No prefix allocated for agent '{agent_id}'. Run 'nxthdr probing agent list' to see available agents."
                 ))?;
             let user_prefix = &agent_entry.prefixes.first()
                 .ok_or_else(|| anyhow::anyhow!("Agent '{agent_id}' has no configured prefix"))?
@@ -199,8 +199,8 @@ pub async fn send(
     output::kv(&pairs);
 
     let hint = agent_src.iter().map(|(_, ip)| format!("--src-ip {ip}")).collect::<Vec<_>>().join(" ");
-    output::hint(&format!("nxthdr probing measurement status {}", response.id));
-    output::hint(&format!("nxthdr probing results {hint}"));
+    output::hint(&format!("nxthdr probing measurement get {}", response.id));
+    output::hint(&format!("nxthdr probing reply list {hint}"));
 
     Ok(())
 }
@@ -365,7 +365,7 @@ pub async fn measurements(
     if measurements.is_empty() {
         if !output::empty(&["id", "started", "agents", "probes", "status"]) {
             output::info("no measurements found");
-            output::hint("nxthdr probing send --agent <id> probes.csv");
+            output::hint("nxthdr probing measurement send --agent <id> probes.csv");
         }
         return Ok(());
     }
@@ -382,7 +382,7 @@ pub async fn measurements(
     }).collect();
 
     output::table(&["id", "started", "agents", "probes", "status"], &rows);
-    output::hint("nxthdr probing measurement status <id>");
+    output::hint("nxthdr probing measurement get <id>");
 
     Ok(())
 }
@@ -467,7 +467,7 @@ pub async fn cancel(id: &str) -> anyhow::Result<()> {
         ("agents_cancelled", &resp.agents_cancelled.to_string()),
         ("message", &resp.message),
     ]);
-    output::hint(&format!("nxthdr probing measurement status {id}"));
+    output::hint(&format!("nxthdr probing measurement get {id}"));
 
     Ok(())
 }


### PR DESCRIPTION
Reworks the whole CLI command surface onto **one rule** — `<group> <resource> <verb>` (gh/docker style) — replacing the previous mix of bare list-nouns, bare verbs, and singular resource groups.

### New structure
```
peering
  asn get
  prefix list | request <h> | revoke <p> | routes | rpki {enable,disable} <p>
  lookup <prefix>
  peerlab env
probing
  agent list
  credits
  measurement send <file> | list [filters] | get <id> | cancel <id>
  reply list --src-ip ...
```

### Renames (BREAKING — beta, pre-1.0)
| Old | New |
|---|---|
| `probing agents` | `probing agent list` |
| `probing send` | `probing measurement send` |
| `probing measurements` | `probing measurement list` |
| `probing measurement-status` → `measurement status` | `probing measurement get` |
| `probing cancel` → `measurement cancel` | `probing measurement cancel` |
| `probing results` | `probing reply list` |
| `peering asn` | `peering asn get` |
| `peering routes` | `peering prefix routes` |

`credits`, `peering prefix {list,request,revoke,rpki}`, `peering lookup`, `peering peerlab env` keep their paths. Handler functions are unchanged — only routing + the next-step hint strings moved. Build + clippy clean; full `--help` tree verified.

Land before the next release tag. Docs PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)