### PR TITLE
ci: crates.io Trusted Publishing (OIDC) + tag/version guard

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,11 +22,27 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ tests ]
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write   # required for crates.io Trusted Publishing (OIDC)
+      contents: read
     steps:
     - uses: actions/checkout@v7
     - uses: Swatinem/rust-cache@v2
+    - name: Verify tag matches Cargo.toml version
+      run: |
+        tag="${GITHUB_REF_NAME#v}"
+        version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+        if [ "$tag" != "$version" ]; then
+          echo "::error::Tag '${GITHUB_REF_NAME}' does not match Cargo.toml version '${version}'"
+          exit 1
+        fi
+    - name: Authenticate to crates.io (Trusted Publishing)
+      uses: rust-lang/crates-io-auth-action@v1
+      id: auth
     - name: Publish to crates.io
-      run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   docker:
     strategy:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ All service endpoints fall back to production but can be overridden via env vars
 
 ## Releasing
 
-Publishing to crates.io is **git-tag-driven**: the `publish` job in `cicd.yml` runs `cargo publish` only on a `refs/tags/` push (after `tests` pass). To cut a release:
+Publishing to crates.io is **git-tag-driven**: the `publish` job in `cicd.yml` runs `cargo publish` only on a `refs/tags/` push (after `tests` pass). Auth is **crates.io Trusted Publishing (OIDC)** — `rust-lang/crates-io-auth-action` mints a short-lived token at run time (auto-revoked when the job ends), so there is **no `CARGO_REGISTRY_TOKEN` secret**. The trust is configured on crates.io (crate Settings → Trusted Publishing → GitHub: owner `nxthdr`, repo `cli`, workflow `cicd.yml`, no environment); the job needs `id-token: write`. To cut a release:
 
 1. Bump `version` in `Cargo.toml` (semver — breaking command changes warrant a minor bump pre-1.0). Commit as `chore: Release nxthdr version X.Y.Z` and land it on `main`.
 2. Tag that commit and push the tag (tags are not ruleset-protected, so this is a direct push):
@@ -37,7 +37,7 @@ Publishing to crates.io is **git-tag-driven**: the `publish` job in `cicd.yml` r
    ```
 3. The tag push publishes `nxthdr` X.Y.Z to crates.io and pushes docker images tagged `X.Y.Z` / `X.Y`.
 
-Gotchas: the `Cargo.toml` version must equal the tag **and** be a not-yet-published version — `cargo publish` hard-fails on a duplicate, and CI does **not** cross-check tag vs. version, so the bump must land *before* tagging. `Cargo.lock` is gitignored (nothing to bump).
+Gotchas: the `Cargo.toml` version must be a not-yet-published version — `cargo publish` hard-fails on a duplicate. The `publish` job now **verifies the tag matches `Cargo.toml`** (stripping the leading `v`) and fails fast on a mismatch, so the version bump must land on `main` *before* you tag. `Cargo.lock` is gitignored (nothing to bump).
 
 ## Architecture
 


### PR DESCRIPTION
## Why
The v0.6.0 release publish failed: `cargo publish --token` ran with an **empty token** because `nxthdr/cli` has no `CARGO_REGISTRY_TOKEN` secret. Rather than re-add a long-lived token that can expire / fall out of org scope again, switch to crates.io **Trusted Publishing**.

## What changed (`cicd.yml` publish job)
- Uses [`rust-lang/crates-io-auth-action@v1`](https://github.com/rust-lang/crates-io-auth-action) to exchange a GitHub OIDC token for a **short-lived crates.io token** (auto-revoked when the job ends). No stored secret.
- Adds `permissions: id-token: write` (required for OIDC).
- Adds a **fail-fast guard**: the pushed tag must match the `Cargo.toml` version (closes the "CI doesn't cross-check tag vs version" gotcha noted in CLAUDE.md).
- CLAUDE.md release runbook updated to match.

## Required one-time setup (crates.io, maintainer-only)
On crates.io → the `nxthdr` crate → **Settings → Trusted Publishing → Add GitHub publisher**:
- Owner: `nxthdr` · Repo: `cli` · Workflow filename: `cicd.yml` · Environment: *(blank)*

## After merge — finishing the stuck 0.6.0 release
0.6.0 is merged + tagged + on Docker, but **not on crates.io** (still 0.5.0). Once this lands and the trusted publisher is configured, re-point the tag at the new `main` HEAD (version is still 0.6.0) to re-run publish with the new workflow:
```bash
git push origin :v0.6.0 && git tag -f v0.6.0 origin/main && git push origin v0.6.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)